### PR TITLE
Add various ways to visualize corner geometry

### DIFF
--- a/corner-visualizer/corner-geometry.html
+++ b/corner-visualizer/corner-geometry.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Corner visualizer</title>
+    <title>Corner Geometry</title>
     <style>
         :root {
             font-family: system-ui, san-serif;
@@ -71,10 +71,14 @@
             grid-column: 2;
         }
         
+        .labeled-control.corner {
+            padding: 4px;
+        }
+        
         .control-group {
             grid-column: 1 / 3;
             display: grid;
-            grid-template-columns: 200px 1fr;
+            grid-template-columns: 50px 1fr;
             border: 1px solid #ddd;
             padding: 20px;
         }
@@ -111,7 +115,7 @@
     <script src="../custom-elements/value-slider.js"></script>
     <script src="../custom-elements/popup.js"></script>
 
-    <script src="bezier-intersection.js" type="module"></script>
+    <script src="corner-geometry.js" type="module"></script>
 </head>
 <body>
     <main>
@@ -122,16 +126,26 @@
         <section class="controls">
             <div class="container">
                 <div class="control-group">
-
                     <div class="labeled-control">
-                        <label class="radius-label">X offset</label><value-slider class="slider" id="border-left-width-slider" min="0" max="1" step="0.005" value=0.1></value-slider>
+                        <label class="radius-label">Left width</label><value-slider class="slider" id="border-left-width-slider" min="0" max="1" step="0.005" value=0.15></value-slider>
                     </div>
                     <div class="labeled-control">
-                        <label class="radius-label">Y offset</label><value-slider class="slider" id="border-top-width-slider" min="0" max="1" step="0.005" value=0.1></value-slider>
+                        <label class="radius-label">Top width</label><value-slider class="slider" id="border-top-width-slider" min="0" max="1" step="0.005" value=0.15></value-slider>
                     </div>
 
                     <div class="labeled-control">
-                        <label class="s-label">S</label><value-slider class="slider" id="s-slider" min="-15" max="15" step="0.01" value="1"></value-slider>
+                        <label class="radius-label">Left Radius</label><value-slider class="slider" id="border-left-radius-slider" min="0" max="1" step="0.005" value=0.5></value-slider>
+                    </div>
+                    <div class="labeled-control">
+                        <label class="radius-label">Top Radius</label><value-slider class="slider" id="border-top-radius-slider" min="0" max="1" step="0.005" value=0.5></value-slider>
+                    </div>
+
+                    <div class="labeled-control">
+                        <label class="s-label">S</label><value-slider class="slider" id="s-slider" min="-15" max="15" step="0.01" value="-0.25"></value-slider>
+                    </div>
+
+                    <div class="corner labeled-control">
+                         <label class="s-label">Corner:</label><custom-popup id="corner-select"></custom-popup>
                     </div>
 
                     <div class="labeled-control">
@@ -139,27 +153,13 @@
                             <input id="show-control-points" type="checkbox" checked><label for="show-control-points">Show control points</label>
                         </div>
                         <div class="checkbox">
-                            <input id="show-classic-se" type="checkbox"><label for="show-classic-se">Show <span style="color: red">classic superellipse</span></label>
-                        </div>
-                        <div class="checkbox">
-                            <input id="show-math-se" type="checkbox"><label for="show-math-se">Show <span style="color: purple">t-interpolated superellipse</span></label>
-                        </div>
-                        <div class="checkbox">
-                            <input id="show-bezier-se" type="checkbox" checked><label for="show-bezier-se">Show <span style="color: gray">bezier superellipse<span></label>
+                            <input id="show-corner-details" type="checkbox" checked><label for="show-corner-details">Show corner details<span></label>
                         </div>
                     </div>
                 </div>
-
             </div>
         </section>
         <section class="explanation">
-            <p>This view compares rendering of the classic superellipse (<code>x^k + y^k = 1</code>) in green, with a rendering based on <code>t</code> interpolation (purple) and a derived bezier curve (gray, with control points.)</p>
-            
-            <p>The slider controls the curvature param <code>s</code>, which is mapped to <code>k</code> via <code>k = Math.pow(2, s)</code>.
-
-            <p>For symmetry around <code>s=0</code>, the <code>t</code> interpolation and bezier curves use <code>abs(s)</code> mapped into the negative s region, hence the deviation from the green line.</p>
-
-            <p>The red point demonstrates the math to compute Y given X.</p>
         </section>
     </main>
 

--- a/corner-visualizer/corner-geometry.js
+++ b/corner-visualizer/corner-geometry.js
@@ -1,0 +1,362 @@
+import {
+    CornerMath,
+    CornerCurve,
+    CornerUtils,
+    cornerTopLeft,
+    cornerTopRight,
+    cornerBottomRight,
+    cornerBottomLeft,    
+} from "./improved-corner-math.js";
+
+const corners = [
+    {
+        name: 'top left',
+        value: 'topleft',
+        data: cornerTopLeft
+    },
+    {
+        name: 'top right',
+        value: 'topright',
+        data: cornerTopRight
+    },
+    {
+        name: 'bottom right',
+        value: 'bottomright',
+        data: cornerBottomRight
+    },
+    {
+        name: 'bottom left',
+        value: 'bottomleft',
+        data: cornerBottomLeft
+    }
+];
+
+class Parameters {
+    constructor()
+    {
+        this.corner = cornerTopLeft;
+
+        // These are fractions.
+        this.verticalBorderRadius = 0.2;
+        this.horizontalBorderRadius = 0.2;
+
+        this.verticalBorderWidth = 0.2;
+        this.horizontalBorderWidth = 0.2;
+
+        this.superEllipseS = 1;
+
+        this.showControlPoints = true;
+        this.showCornerDetails = true;
+    }
+}
+
+class GraphRenderer {
+    constructor(canvasElement)
+    {
+        this.canvasElement = canvasElement;
+
+        this.#computeCanvasSize();
+        
+        this.boxMargin = 100;
+    }
+    
+    set parameters(params)
+    {
+        this._parameters = params;
+        this.draw();
+    }
+    
+    draw()
+    {
+        const context = this.canvasElement.getContext('2d');
+        context.clearRect(0, 0, this.renderingWidth, this.renderingHeight);
+
+        const boxLeft = this.boxMargin;
+        const boxTop = this.boxMargin;
+
+        const boxSize = new Size(
+            this.renderingWidth - 2 * this.boxMargin,
+            this.renderingHeight - 2 * this.boxMargin
+        );
+
+        const boxRight = boxSize.width;
+        const boxBottom = boxSize.height;
+
+        const topEdge = -this.boxMargin;
+        const leftEdge = -this.boxMargin;
+        const bottomEdge = boxSize.height + this.boxMargin;
+        const rightEdge = boxSize.width + this.boxMargin;
+        
+        const verticalBorderWidth = this._parameters.verticalBorderWidth * boxSize.width;
+        const horizontalBorderWidth = this._parameters.horizontalBorderWidth * boxSize.height;
+
+        const verticalRadius = this._parameters.verticalBorderRadius * boxSize.width;
+        const horizontalRadius = this._parameters.horizontalBorderRadius * boxSize.height;
+
+        const radiusSize = new Size(horizontalRadius, verticalRadius);
+
+        const graphScale = new Size(boxSize.width, -boxSize.height);
+        
+        context.save();
+        context.translate(boxLeft, boxTop);
+
+        const pointToGraph = (p) => {
+            const offset = p.scaledBy(graphScale);
+            return offset.movedBy(new Size(0, boxSize.height));
+        };
+        
+        const mapToCorner = (p) => {
+            return CornerUtils.mapToCorner(this._parameters.corner, p, boxSize);
+        };
+
+        function showDot(p, color)
+        {
+            const dotRadius = 10;
+
+            context.fillStyle = color;
+            context.beginPath();
+            context.arc(p.x, p.y, dotRadius, 0, 2 * Math.PI);
+            context.fill();
+        }
+
+        function showControlPoint(anchorPoint, controlPoint, color)
+        {
+            const dotRadius = 10;
+
+            context.save();
+            context.beginPath();
+            context.moveTo(anchorPoint.x, anchorPoint.y);
+            context.lineTo(controlPoint.x, controlPoint.y);
+            context.strokeStyle = 'rgba(0, 0, 0, 0.25)'
+            context.lineWidth = 1;
+            context.stroke();
+
+            context.beginPath();
+            context.arc(controlPoint.x, controlPoint.y, dotRadius, 0, 2 * Math.PI);
+            context.fillStyle = color;
+            context.fill();
+            context.restore();
+        }
+        
+        const showCurve = (graphPoints, lineWidth, strokeStyle) => {
+            context.save();
+
+            if (this._parameters.showControlPoints) {
+                showControlPoint(graphPoints[0], graphPoints[1], controlPointColor);
+                showControlPoint(graphPoints[3], graphPoints[2], controlPointColor);
+
+                if (graphPoints.length > 4) {
+                    showDot(graphPoints[3], controlPointColor);
+                    showControlPoint(graphPoints[3], graphPoints[4], controlPointColor);
+                    showControlPoint(graphPoints[6], graphPoints[5], controlPointColor);
+                }
+            }
+
+            context.beginPath();
+            context.moveTo(graphPoints[0].x, graphPoints[0].y);
+            context.bezierCurveTo(graphPoints[1].x, graphPoints[1].y, graphPoints[2].x, graphPoints[2].y, graphPoints[3].x, graphPoints[3].y);
+
+            if (graphPoints.length > 4)
+                context.bezierCurveTo(graphPoints[4].x, graphPoints[4].y, graphPoints[5].x, graphPoints[5].y, graphPoints[6].x, graphPoints[6].y);
+
+            context.lineWidth = lineWidth;
+            context.strokeStyle = strokeStyle;
+            context.stroke();
+            context.restore();
+        };
+
+        // Box outline
+        {
+            context.save();
+            context.lineWidth = 1;
+            context.strokeStyle = '#ccc';
+            
+            const outsideTopLeftPoints = [
+                new Point(0, bottomEdge),
+                new Point(0, 0),
+                new Point(rightEdge, 0),
+            ];
+
+            const insideTopLeftPoints = [
+                new Point(verticalBorderWidth, bottomEdge),
+                new Point(verticalBorderWidth, horizontalBorderWidth),
+                new Point(rightEdge, horizontalBorderWidth),
+            ];
+            
+            const outsidePoints = outsideTopLeftPoints.map(p => mapToCorner(p));
+            const insidePoints = insideTopLeftPoints.map(p => mapToCorner(p));
+        
+            // Outside
+            context.beginPath();
+            context.moveTo(outsidePoints[0].x, outsidePoints[0].y);
+            context.lineTo(outsidePoints[1].x, outsidePoints[1].y);
+            context.lineTo(outsidePoints[2].x, outsidePoints[2].y);
+
+            // Inside
+            context.moveTo(insidePoints[0].x, insidePoints[0].y);
+            context.lineTo(insidePoints[1].x, insidePoints[1].y);
+            context.lineTo(insidePoints[2].x, insidePoints[2].y);
+
+            context.stroke();
+            context.restore();
+        }
+
+        const cornerStartPoint = new Point(0, verticalRadius);
+        const cornerEndPoint = new Point(horizontalRadius, 0);
+
+        const startPoint = mapToCorner(cornerStartPoint);
+        const endPoint = mapToCorner(cornerEndPoint);
+        
+        // Corner joins
+        const controlPointColor = 'rgba(0, 0, 0, 0.35)';
+        {
+            context.save();
+            showDot(startPoint, controlPointColor);
+            showDot(endPoint, controlPointColor);
+            context.restore();
+        }
+
+        const s = this._parameters.superEllipseS;
+        const k = CornerMath.sToK(s);
+
+        const cornerCurve = CornerCurve.canonicalCurveForCorner(s, radiusSize);
+
+        // Outer curve
+        {
+            const graphPoints = cornerCurve.points.map(p => mapToCorner(p));
+            showCurve(graphPoints, 2, 'silver');
+        }
+        
+        const curvatureOffset = CornerMath.offsetForCurvature(s);
+        const canonicalStartOffsetPoint = cornerStartPoint.movedBy(curvatureOffset.scaledBy(new Size(verticalBorderWidth, verticalBorderWidth)));
+        const canonicalEndOffsetPoint = cornerEndPoint.movedBy(curvatureOffset.flipped().scaledBy(new Size(horizontalBorderWidth, horizontalBorderWidth)));
+
+        const startOffsetPoint = mapToCorner(canonicalStartOffsetPoint);
+        const endOffsetPoint = mapToCorner(canonicalEndOffsetPoint);
+        showDot(startOffsetPoint, 'red');
+        showDot(endOffsetPoint, 'blue');
+
+        const canonicalAdjustedInnerCorner = new Point(canonicalStartOffsetPoint.x, canonicalEndOffsetPoint.y);
+        const needsInnerArc = canonicalStartOffsetPoint.y > horizontalBorderWidth && canonicalEndOffsetPoint.x > verticalBorderWidth;
+        const needsTrimmedInnerArc = canonicalStartOffsetPoint.x < verticalBorderWidth || canonicalEndOffsetPoint.y < horizontalBorderWidth;
+
+        if (needsInnerArc) {
+            const innerCornerScale = new Size(Math.abs(startOffsetPoint.x - endOffsetPoint.x), Math.abs(startOffsetPoint.y - endOffsetPoint.y));
+            const innerCornerCurve = CornerCurve.canonicalCurveForCorner(s, innerCornerScale);
+            const graphPoints = innerCornerCurve.points.map(p => mapToCorner(p.movedBy(new Size(canonicalStartOffsetPoint.x, canonicalEndOffsetPoint.y))));
+
+            if (needsTrimmedInnerArc) {
+                showCurve(graphPoints, 2, 'silver');
+
+                const innerCornerScale = new Size(Math.abs(canonicalStartOffsetPoint.x - canonicalEndOffsetPoint.x), Math.abs(canonicalStartOffsetPoint.y - canonicalEndOffsetPoint.y));
+                const innerCornerCurve = CornerCurve.canonicalCurveForCorner(s, innerCornerScale);
+
+                if (canonicalStartOffsetPoint.y > horizontalBorderWidth && canonicalEndOffsetPoint.x > verticalBorderWidth) {
+                    const splitCurve = innerCornerCurve.cornerCurveTruncatingAtXAndY(Math.max(verticalBorderWidth - canonicalStartOffsetPoint.x, 0), Math.max(horizontalBorderWidth - canonicalEndOffsetPoint.y, 0));
+                    const mappedPoints = splitCurve.points.map(p => mapToCorner(p.movedBy(new Size(canonicalStartOffsetPoint.x, canonicalEndOffsetPoint.y))));
+
+                    if (mappedPoints.length)
+                        showCurve(mappedPoints, 4, 'green');
+                }
+            } else {
+                showCurve(graphPoints, 4, 'green');
+            }
+        }
+
+        context.restore();
+    }
+
+    #computeCanvasSize()
+    {
+        const canvasRect = this.canvasElement.getBoundingClientRect();
+        
+        this.scale = window.devicePixelRatio;
+        this.renderingWidth = canvasRect.width * this.scale;
+        this.renderingHeight = canvasRect.height * this.scale;
+
+        this.canvasElement.width = this.renderingWidth;
+        this.canvasElement.height = this.renderingHeight;
+    }  
+};
+
+class WindowController {
+    constructor()
+    {
+        this.canvasElement = document.getElementById('preview-canvas');
+
+        this.parameters = new Parameters();
+        this.graphRenderer = new GraphRenderer(this.canvasElement);
+        this.#registerCustomElements();
+        this.#connectControls();
+    }
+
+    #registerCustomElements()
+    {
+        window.customElements.define("custom-popup", PopupElement);   
+        window.customElements.define("value-slider", ValueSlider);   
+    }
+
+    #connectControls()
+    {
+        const setupSlider = (sliderID, paramName) => {
+            const slider = document.getElementById(sliderID);
+            slider.oninput = (event) => {
+                this.parameters[paramName] = parseFloat(slider.value);
+                this.#parametersChanged();
+            }
+            
+            this.parameters[paramName] = parseFloat(slider.value);
+        }
+
+        setupSlider('s-slider', 'superEllipseS');
+
+        setupSlider('border-left-width-slider', 'verticalBorderWidth');
+        setupSlider('border-top-width-slider', 'horizontalBorderWidth');
+
+        setupSlider('border-left-radius-slider', 'verticalBorderRadius');
+        setupSlider('border-top-radius-slider', 'horizontalBorderRadius');
+
+        const setupCheckbox = (checkboxID, paramName) => {
+            const checkbox = document.getElementById(checkboxID);
+            checkbox.addEventListener('change', (event) => {
+                this.parameters[paramName] = event.target.checked;
+                this.#parametersChanged();
+            });
+            this.parameters[paramName] = checkbox.checked;
+            
+        };
+
+        const cornerSelect = document.getElementById('corner-select');
+        cornerSelect.setValues(corners);
+        cornerSelect.addEventListener('change', () => {
+            for (const item of corners) {
+                if (item.value === cornerSelect.currentValue) {
+                    this.#cornerChanged(item.data);
+                    break;
+                }
+            }
+        });
+        cornerSelect.selectedIndex = 0;
+
+        setupCheckbox('show-control-points', 'showControlPoints');
+        setupCheckbox('show-corner-details', 'showCornerDetails');
+
+        this.#parametersChanged();
+    }
+    
+    #cornerChanged(value)
+    {
+        this.parameters.corner = value;
+        this.#parametersChanged();
+    }
+
+    #parametersChanged()
+    {
+        this.graphRenderer.parameters = this.parameters;
+    }
+}
+
+let windowController;
+window.addEventListener('load', () => {
+    windowController = new WindowController();
+}, false);

--- a/corner-visualizer/corner-renderer.js
+++ b/corner-visualizer/corner-renderer.js
@@ -1,0 +1,552 @@
+import {
+    CornerMath,
+    CornerCurve,
+    CornerUtils,
+    cornerTopLeft,
+    cornerTopRight,
+    cornerBottomRight,
+    cornerBottomLeft,    
+} from "./improved-corner-math.js";
+
+export const cornerStyleNone = 'none';
+export const cornerStyleStraight = 'straight';
+export const cornerStyleRound = 'round';
+export const cornerStyleNotch = 'notch';
+export const cornerStyleBevel = 'bevel';
+export const cornerStyleScoop = 'scoop';
+export const cornerStyleSuperellipse = 'superellipse';
+export const cornerStyleSuperellipseApproximation = 'superellipseapprox';
+export const cornerStyleContinuousRounded = 'continuous-rounded';
+
+const shapeIDSample = 'sample';
+const shapeIDReference = 'reference';
+
+export class ShapeParameters {
+    constructor()
+    {
+        // These are fractions.
+        this.borderRadiusWidth = 0.2;
+        this.borderRadiusHeight = 0.2;
+
+        this.borderLeftWidth = 0.1;
+        this.borderTopWidth = 0.1;
+
+        this.superEllipseParam = 1;
+
+        this.cornerStyle = cornerStyleRound;
+        
+        this.showControlPoints = true;
+    }
+}
+
+export class BorderRenderer {
+    constructor(canvasElement, parameters)
+    {
+        this.canvasElement = canvasElement;
+        this._parameters = structuredClone(parameters);
+        
+        this.#computeCanvasSize();
+        
+        this.boxMargin = 50;
+    }
+    
+    set parameters(parameters)
+    {
+        this._parameters = structuredClone(parameters);
+        this.paint(); // FIXME: do on a rAF callback.
+    }
+
+    get parameters()
+    {
+        return this._parameters;
+    }
+    
+    paint()
+    {
+        const context = this.canvasElement.getContext('2d');
+        context.clearRect(0, 0, this.renderingWidth, this.renderingHeight);
+
+        const boxLeft = this.boxMargin;
+        const boxTop = this.boxMargin;
+        
+        context.save();
+        context.translate(boxLeft, boxTop);
+
+        const boxSize = new Size(
+            this.renderingWidth - 2 * this.boxMargin,
+            this.renderingHeight - 2 * this.boxMargin
+        );
+        
+        this.#drawBox(context, boxSize);
+
+        context.lineWidth = this.scale * 1;
+
+        const outerBorderWidths = {
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+        };
+        
+        const outerShape = this.#createShape(this._parameters.cornerStyle, boxSize, outerBorderWidths);
+
+        const leftBorderWidth = boxSize.width * this._parameters.borderLeftWidth;
+        const topBorderWidth = boxSize.height * this._parameters.borderTopWidth;
+        
+        const borderWidths = {
+            top: topBorderWidth,
+            right: leftBorderWidth,
+            bottom: topBorderWidth,
+            left: leftBorderWidth,
+        };
+
+        const innerShape = this.#createInnerShape(this._parameters.cornerStyle, boxSize, borderWidths);
+
+        const showFill = true;
+        if (showFill) {
+            const outerPath = this.#pathFromShape(outerShape);
+            const innerPath = this.#pathFromShape(innerShape);
+            
+            outerPath.addPath(innerPath);
+            
+            context.fillStyle = 'rgba(0, 128, 0, 0.3)';
+            context.fill(outerPath, "evenodd");
+        }
+
+        context.strokeStyle = 'black';
+        this.#drawShape(context, outerShape, this._parameters.showControlPoints);
+
+        {
+            context.save();
+            this.#drawShape(context, innerShape, this._parameters.showControlPoints);
+            context.restore();
+        }
+
+        context.restore();
+    }
+    
+    #computeCanvasSize()
+    {
+        const canvasRect = this.canvasElement.getBoundingClientRect();
+        
+        this.scale = window.devicePixelRatio;
+        this.renderingWidth = canvasRect.width * this.scale;
+        this.renderingHeight = canvasRect.height * this.scale;
+
+        this.canvasElement.width = this.renderingWidth;
+        this.canvasElement.height = this.renderingHeight;
+    }
+    
+    #drawBox(context, boxSize)
+    {
+        context.fillStyle = 'rgba(0, 0, 0, 0.04)';
+        context.fillRect(0, 0, boxSize.width, boxSize.height);
+    }
+    
+    // Top left of the box is assumed to be a 0,0
+    #createShape(cornerStyle, outerBoxSize, borderWidths)
+    {
+        const shapeSegments = [];
+
+        this.#addShapeCorner(shapeSegments, cornerStyle, outerBoxSize, borderWidths, cornerTopLeft);
+        this.#addShapeCorner(shapeSegments, cornerStyle, outerBoxSize, borderWidths, cornerTopRight);
+        this.#addShapeCorner(shapeSegments, cornerStyle, outerBoxSize, borderWidths, cornerBottomRight);
+        this.#addShapeCorner(shapeSegments, cornerStyle, outerBoxSize, borderWidths, cornerBottomLeft);
+
+        shapeSegments.push(new ShapeSegmentClose());
+
+        const shape = new Shape();
+        shape.segments = shapeSegments;
+        return shape;
+    }
+
+    #createInnerShape(cornerStyle, outerBoxSize, borderWidths)
+    {
+        switch (cornerStyle) {
+        case cornerStyleStraight:
+        case cornerStyleRound:
+        case cornerStyleContinuousRounded: {
+            return this.#createShape(cornerStyle, outerBoxSize, borderWidths);
+        }
+        case cornerStyleScoop:
+        case cornerStyleNotch:
+        case cornerStyleBevel:
+        case cornerStyleSuperellipse:
+            break;
+        }
+
+        const shapeSegments = [];
+
+        this.#addShapeSuperellipseInnerCorner(shapeSegments, outerBoxSize, borderWidths, cornerTopLeft);
+        this.#addShapeSuperellipseInnerCorner(shapeSegments, outerBoxSize, borderWidths, cornerTopRight);
+        this.#addShapeSuperellipseInnerCorner(shapeSegments, outerBoxSize, borderWidths, cornerBottomRight);
+        this.#addShapeSuperellipseInnerCorner(shapeSegments, outerBoxSize, borderWidths, cornerBottomLeft);
+        shapeSegments.push(new ShapeSegmentClose());
+
+        const shape = new Shape();
+        shape.segments = shapeSegments;
+        return shape;
+    }
+
+    #addShapeCorner(shapeSegments, cornerStyle, outerBoxSize, borderWidths, corner)
+    {
+        switch (cornerStyle) {
+        case cornerStyleStraight:
+            this.#addShapeStraightCorner(shapeSegments, outerBoxSize, borderWidths, corner);
+            break;
+        case cornerStyleRound:
+            this.#addShapeRoundedCorner(shapeSegments, outerBoxSize, borderWidths, corner);
+            break;
+        case cornerStyleScoop:
+        case cornerStyleNotch:
+        case cornerStyleBevel:
+        case cornerStyleSuperellipse:
+            this.#addShapeSuperellipseCorner(shapeSegments, outerBoxSize, borderWidths, corner);
+            break;
+        case cornerStyleContinuousRounded:
+            this.#addShapeContinuousRoundedCorner(shapeSegments, outerBoxSize, borderWidths, corner);
+            break;
+        }
+    }
+        
+    #addShapeStraightCorner(shapeSegments, outerBoxSize, borderWidths, corner)
+    {
+        const topLeftPoint = this.#pointForCorner(corner, borderWidths);
+        const cornerPoint = CornerUtils.mapToCorner(corner, topLeftPoint, outerBoxSize);
+
+        if (shapeSegments.length === 0)
+            shapeSegments.push(new ShapeSegmentMove(Absolute, cornerPoint));
+        else
+            shapeSegments.push(new ShapeSegmentLine(Absolute, cornerPoint));
+    }
+
+    #addShapeRoundedCorner(shapeSegments, outerBoxSize, borderWidths, corner)
+    {
+        const topLeftPoint = this.#pointForCorner(corner, borderWidths);
+        const cornerSize = this.#cornerSize(outerBoxSize, corner);
+        const constrainedRadius = new Size(Math.max(cornerSize.width - topLeftPoint.x, 0), Math.max(cornerSize.height - topLeftPoint.y, 0));
+
+        if (constrainedRadius.width == 0 || constrainedRadius.height === 0) {
+            const cornerPoint = CornerUtils.mapToCorner(corner, topLeftPoint, outerBoxSize);
+
+            if (shapeSegments.length === 0)
+                shapeSegments.push(new ShapeSegmentMove(Absolute, cornerPoint));
+            else
+                shapeSegments.push(new ShapeSegmentLine(Absolute, cornerPoint));
+            
+            return;
+        }
+        
+        const controlPointOffsetFromCorner = constrainedRadius.scaledBy(new Size(circleControlPoint, circleControlPoint));
+
+        // p1, c1, c2, p2
+        const points = [
+            new Point(0, constrainedRadius.height),
+            new Point(0, controlPointOffsetFromCorner.height),
+            new Point(controlPointOffsetFromCorner.width, 0),
+            new Point(constrainedRadius.width, 0),
+        ];
+
+        if (corner === cornerTopRight || corner == cornerBottomLeft)
+            points.reverse();
+        
+        const cornerOffset = new Size(topLeftPoint.x, topLeftPoint.y);
+        const mappedPoints = points.map(p => CornerUtils.mapToCorner(corner, p.movedBy(cornerOffset), outerBoxSize));
+
+        if (shapeSegments.length === 0)
+            shapeSegments.push(new ShapeSegmentMove(Absolute, mappedPoints[0]));
+        else
+            shapeSegments.push(new ShapeSegmentLine(Absolute, mappedPoints[0]));
+        
+        shapeSegments.push(new ShapeSegmentCurve(Absolute, mappedPoints[1], mappedPoints[2], mappedPoints[3]));
+    }
+
+    #addShapeSuperellipseCorner(shapeSegments, outerBoxSize, borderWidths, corner)
+    {
+        const cornerSize = this.#cornerSize(outerBoxSize, corner);
+
+        const s = this._parameters.superEllipseParam;
+        const cornerCurve = CornerCurve.canonicalCurveForCorner(s, cornerSize);
+        const cornerPoints = cornerCurve.points.map(p => CornerUtils.mapToCorner(corner, p, outerBoxSize));
+        
+        if (corner === cornerTopRight || corner == cornerBottomLeft)
+            cornerPoints.reverse();
+
+        if (shapeSegments.length === 0)
+            shapeSegments.push(new ShapeSegmentMove(Absolute, cornerPoints[0]));
+        else
+            shapeSegments.push(new ShapeSegmentLine(Absolute, cornerPoints[0]));
+
+        shapeSegments.push(new ShapeSegmentCurve(Absolute, cornerPoints[1], cornerPoints[2], cornerPoints[3]));
+
+        if (cornerPoints.length === 7)
+            shapeSegments.push(new ShapeSegmentCurve(Absolute, cornerPoints[4], cornerPoints[5], cornerPoints[6]));
+    }
+
+    #addShapeSuperellipseInnerCorner(shapeSegments, outerBoxSize, borderWidths, corner)
+    {
+        const s = this._parameters.superEllipseParam;
+        const cornerSize = this.#cornerSize(outerBoxSize, corner);
+        const cornerPoint = this.#pointForCorner(corner, borderWidths);
+
+        const addShapeSegments = (corner, points) => {
+            if (corner === cornerTopLeft)
+                shapeSegments.push(new ShapeSegmentMove(Absolute, points[0]));
+            else
+                shapeSegments.push(new ShapeSegmentLine(Absolute, points[0]));
+
+            shapeSegments.push(new ShapeSegmentCurve(Absolute, points[1], points[2], points[3]));
+            if (points.length === 7)
+                shapeSegments.push(new ShapeSegmentCurve(Absolute, points[4], points[5], points[6]));
+        };
+
+        const renderInnerArc = (corner) => {
+            // We compute in terms of (0, 0), then map to the appropriate corner.
+            const startPoint = new Point(0, cornerSize.height);
+            const endPoint = new Point(cornerSize.width, 0);
+
+            const curvatureOffset = CornerMath.offsetForCurvature(s);
+            const startOffsetPoint = startPoint.movedBy(curvatureOffset.scaledBy(new Size(cornerPoint.x, cornerPoint.x)));
+            const endOffsetPoint = endPoint.movedBy(curvatureOffset.flipped().scaledBy(new Size(cornerPoint.y, cornerPoint.y)));
+
+            const needsInnerArc = startOffsetPoint.y > cornerPoint.y && endOffsetPoint.x > cornerPoint.x;
+            if (!needsInnerArc)
+                return false;
+
+            const innerCornerScale = new Size(Math.abs(startOffsetPoint.x - endOffsetPoint.x), Math.abs(startOffsetPoint.y - endOffsetPoint.y));
+            
+            // FIXME: We call `CornerCurve.canonicalCurveForCorner` for both inner and outer shapes. It would be more efficient to do it only once.
+            let innerCornerCurve = CornerCurve.canonicalCurveForCorner(s, innerCornerScale);
+
+            const needsTrimmedInnerArc = startOffsetPoint.x < cornerPoint.x || endOffsetPoint.y < cornerPoint.y;
+            if (needsTrimmedInnerArc && startOffsetPoint.y > cornerPoint.y && endOffsetPoint.x > cornerPoint.x)
+                innerCornerCurve = innerCornerCurve.cornerCurveTruncatingAtXAndY(Math.max(cornerPoint.x - startOffsetPoint.x, 0), Math.max(cornerPoint.y - endOffsetPoint.y, 0));
+
+            const cornerInset = new Size(startOffsetPoint.x, endOffsetPoint.y);
+            const mappedPoints = innerCornerCurve.points.map(p => CornerUtils.mapToCorner(corner, p.movedBy(cornerInset), outerBoxSize));
+            if (mappedPoints.length === 0)
+                return false;
+
+            if (corner === cornerTopRight || corner == cornerBottomLeft)
+                mappedPoints.reverse();
+
+            addShapeSegments(corner, mappedPoints);
+            return true;
+        }
+        
+        if (!renderInnerArc(corner)) {
+            const insideCorner = CornerUtils.mapToCorner(corner, cornerPoint, outerBoxSize);
+
+            if (corner === cornerTopLeft)
+                shapeSegments.push(new ShapeSegmentMove(Absolute, insideCorner));
+            else
+                shapeSegments.push(new ShapeSegmentLine(Absolute, insideCorner));
+        }
+    }
+    
+    #addShapeContinuousRoundedCorner(shapeSegments, outerBoxSize, borderWidths, corner)
+    {
+        const topLeftPoint = this.#pointForCorner(corner, borderWidths);
+        const cornerSize = this.#cornerSize(outerBoxSize, corner);
+        const constrainedRadius = new Size(Math.max(cornerSize.width - topLeftPoint.x, 0), Math.max(cornerSize.height - topLeftPoint.y, 0));
+
+        if (constrainedRadius.width == 0 || constrainedRadius.height === 0) {
+            const cornerPoint = CornerUtils.mapToCorner(corner, topLeftPoint, outerBoxSize);
+
+            if (shapeSegments.length === 0)
+                shapeSegments.push(new ShapeSegmentMove(Absolute, cornerPoint));
+            else
+                shapeSegments.push(new ShapeSegmentLine(Absolute, cornerPoint));
+            
+            return;
+        }
+        
+        const unitPoints = [
+            new Point(0, 1.528660),         // p1
+
+            new Point(0, 1.08849),          // c1
+            new Point(0, 0.868407),         // c2
+            new Point(0.0749114, 0.631494), // p2
+
+            new Point(0.169060, 0.372824),  // c3
+            new Point(0.372824, 0.16906),   // c4
+            new Point(0.631494, 0.0749114), // p3
+
+            new Point(0.868407, 0),         // c5
+            new Point(1.088490, 0),         // c6
+            new Point(1.528660, 0)          // p4
+        ];
+
+        const scaledPoints = unitPoints.map(p => p.scaledBy(constrainedRadius));
+
+        if (corner === cornerTopRight || corner == cornerBottomLeft)
+            scaledPoints.reverse();
+        
+        const cornerOffset = new Size(topLeftPoint.x, topLeftPoint.y);
+        const mappedPoints = scaledPoints.map(p => CornerUtils.mapToCorner(corner, p.movedBy(cornerOffset), outerBoxSize));
+
+        if (shapeSegments.length === 0)
+            shapeSegments.push(new ShapeSegmentMove(Absolute, mappedPoints[0]));
+        else
+            shapeSegments.push(new ShapeSegmentLine(Absolute, mappedPoints[0]));
+        
+        shapeSegments.push(new ShapeSegmentCurve(Absolute, mappedPoints[1], mappedPoints[2], mappedPoints[3]));
+        shapeSegments.push(new ShapeSegmentCurve(Absolute, mappedPoints[4], mappedPoints[5], mappedPoints[6]));
+        shapeSegments.push(new ShapeSegmentCurve(Absolute, mappedPoints[7], mappedPoints[8], mappedPoints[9]));
+    }
+
+    #pointForCorner(corner, borderWidths)
+    {
+        switch (corner) {
+        case cornerTopLeft:
+            return new Point(borderWidths.left, borderWidths.top);
+        case cornerTopRight:
+            return new Point(borderWidths.right, borderWidths.top);
+        case cornerBottomRight:
+            return new Point(borderWidths.right, borderWidths.bottom);
+        case cornerBottomLeft:
+            return new Point(borderWidths.left, borderWidths.bottom);
+        }
+        return new Point(0, 0);
+    }
+
+    #cornerSize(boxSize, corner)
+    {
+        return new Size(
+            this._parameters.borderRadiusWidth * boxSize.width,
+            this._parameters.borderRadiusHeight * boxSize.height
+        );
+    }
+
+    #drawControlPoints(context, shape)
+    {
+        const pointRadius = 10;
+        const controlPointLineWidth = 1;
+
+        const iterator = shape.iterator;
+        let it;
+        
+        let previousPosition;
+        
+        while (it = iterator.next()) {
+            switch (it.segment.constructor) {
+            case ShapeSegmentMove:
+            case ShapeSegmentLine:
+                context.beginPath();
+                context.moveTo(it.position.x, it.position.y);
+                context.arc(it.position.x, it.position.y, pointRadius, 0, 2 * Math.PI);
+                context.fillStyle = 'rgba(0, 0, 0, 0.5)';
+                context.fill();
+                break;
+            case ShapeSegmentHorizontalLine:
+            case ShapeSegmentVerticalLine:
+                break;
+            case ShapeSegmentCurve: {
+                const controlPoints = it.segment.controlPointsWithCurrentPoint(it.position);
+
+                context.beginPath();
+                context.moveTo(it.position.x, it.position.y);
+                context.arc(it.position.x, it.position.y, pointRadius, 0, 2 * Math.PI);
+                context.fillStyle = 'rgba(0, 0, 0, 0.5)';
+                context.fill();
+
+                // Line from previous point to first control point.
+                context.beginPath();
+                context.moveTo(previousPosition.x, previousPosition.y);
+                context.lineTo(controlPoints[0].x, controlPoints[0].y);
+                context.lineWidth = controlPointLineWidth;
+                context.stroke();
+
+                context.beginPath();
+                context.moveTo(controlPoints[0].x, controlPoints[0].y);
+                context.arc(controlPoints[0].x, controlPoints[0].y, pointRadius, 0, 2 * Math.PI);
+                context.fillStyle = 'rgba(0, 0, 255, 0.5)';
+                context.fill();
+
+                // Line from current point to second control point.
+                context.beginPath();
+                context.moveTo(it.position.x, it.position.y);
+                context.lineTo(controlPoints[1].x, controlPoints[1].y);
+                context.lineWidth = controlPointLineWidth;
+                context.stroke();
+
+                context.moveTo(controlPoints[1].x, controlPoints[1].y);
+                context.arc(controlPoints[1].x, controlPoints[1].y, pointRadius, 0, 2 * Math.PI);
+
+                context.fillStyle = 'rgba(0, 0, 255, 0.5)';
+                context.fill();
+                break;
+            }
+            case ShapeSegmentQuadraticCurve:
+                break;
+            case ShapeSegmentSmooth:
+                break;
+            case ShapeSegmentQuadraticSmooth:
+                break;
+            case ShapeSegmentArc:
+                break;
+            case ShapeSegmentClose:
+                context.closePath();
+                break;
+            default:
+                console.error('unknown segment type', segment);
+                break;
+            }
+            
+            previousPosition = it.position;
+        }
+    }
+    
+    #drawShape(context, shape, showControlPoints)
+    {
+        context.beginPath();
+
+        const path = this.#pathFromShape(shape);
+        context.stroke(path);
+
+        if (showControlPoints)
+            this.#drawControlPoints(context, shape);   
+    }
+    
+    #pathFromShape(shape)
+    {
+        const path = new Path2D();
+
+        const iterator = shape.iterator;
+        let it;
+        while (it = iterator.next()) {
+            switch (it.segment.constructor) {
+            case ShapeSegmentMove:
+                path.moveTo(it.position.x, it.position.y);
+                break;
+            case ShapeSegmentLine:
+                path.lineTo(it.position.x, it.position.y);
+                break;
+            case ShapeSegmentHorizontalLine:
+            case ShapeSegmentVerticalLine:
+                break;
+            case ShapeSegmentCurve: {
+                const controlPoints = it.segment.controlPointsWithCurrentPoint(it.position);
+                path.bezierCurveTo(controlPoints[0].x, controlPoints[0].y, controlPoints[1].x, controlPoints[1].y, it.position.x, it.position.y);
+                break;
+            }
+            case ShapeSegmentQuadraticCurve:
+                break;
+            case ShapeSegmentSmooth:
+                break;
+            case ShapeSegmentQuadraticSmooth:
+                break;
+            case ShapeSegmentArc:
+                break;
+            case ShapeSegmentClose:
+                path.closePath();
+                break;
+            default:
+                console.error('unknown segment type', segment);
+                break;
+            }
+        }
+
+        return path;
+    }
+}

--- a/corner-visualizer/improved-corner-math.js
+++ b/corner-visualizer/improved-corner-math.js
@@ -1,4 +1,9 @@
 
+export const cornerTopLeft = 0;
+export const cornerTopRight = 1;
+export const cornerBottomRight = 2;
+export const cornerBottomLeft = 3;
+
 export class CornerMath {
 
     // t is distance along the curve. Useful to compute at 0.5.
@@ -66,7 +71,6 @@ export class CornerMath {
         return [P1, P2, P3, P4, P5];
     }
 
-
     // t is distance along the curve. Useful to compute at 0.5.
     static #superellipsePointAtProgress(s, t)
     {
@@ -91,4 +95,355 @@ export class CornerMath {
     {
         return Math.log2(k);
     }
+    
+    static offsetForCurvature(s)
+    {
+      // Find the superellipse's control point.
+      // we do that by approximating the superellipse as a quadratic
+      // curve that has the same point at t = 0.5.
+      // if (s <= 0.001)
+      //     return new Point(1, -1);
+
+      const x = this.superellipsePointAtProgress(s, 0.5).x;
+      const offset = 2 - Math.sqrt(2); // Chosen so that with s=1 (k = 2) this returns { 1, 0 } which is necessary to match historical `corner-shape: round` behavior.
+      const [a, b] = [x, 1 - x].map(m => 2 * m - offset);
+      const result = new Size(Math.max(a, 0), Math.max(b, 0));
+      return result.normalized();
+    }
+}
+
+export class CornerUtils {
+    static mapToCorner(corner, p, boxSize)
+    {
+        // Map a top left point to another corner.
+        switch (corner) {
+        case cornerTopLeft:
+            return p;
+        case cornerTopRight:
+            return new Point(boxSize.width - p.x, p.y);
+        case cornerBottomLeft:
+            return new Point(p.x, boxSize.height - p.y);
+        case cornerBottomRight:
+            return new Point(boxSize.width - p.x, boxSize.height - p.y);
+        }
+        return p;
+    }
+}
+
+// Represents the Bezier curve for a corner, which consists of one or two cubic beziers (4 or 7 points).
+// Point ordering is p1, c1, c2, p2, c3, c4, p3.
+export class CornerCurve {
+    // The canonical curve matches the top left corner, where 0,0 is the outside corner.
+    static canonicalCurveForCorner(s, cornerRadius)
+    {
+        const controlPoints = CornerMath.controlPointsForSuperellipse(s);
+        
+        const curvePoints = [new Point(0, 1)].concat(controlPoints);
+        curvePoints.push(new Point(1, 0));
+        
+        // Maybe we can just do this math as part of controlPointsForSuperellipse.
+        const points = curvePoints.map(p => new Point(1 - p.y, 1 - p.x).scaledBy(cornerRadius));
+        return new CornerCurve(points);
+    }
+    
+    constructor(points)
+    {
+        this._points = points;
+    }
+
+    get points()
+    {
+        return this._points;
+    }
+    
+    cornerCurveTruncatingAtXAndY(x, y)
+    {
+        // We only expect to truncate if we have two segments.
+        if (this._points.length < 7)
+            return this;
+
+        const segment1Points = () => {
+            return this._points.slice(0, 4);
+        };
+
+        const segment2Points = () => {
+            return this._points.slice(3);
+        };
+
+        // We want the part of the curve in the px > x && py > y area.
+        const midpoint = this._points[3];
+        let points = [];
+
+        if (midpoint.x > x && midpoint.y > y) {
+            // Split both segments.
+            const seg1TforX = BezierUtils.tForX(segment1Points(), x);
+            const seg2TforX = BezierUtils.tForX(segment2Points(), x);
+
+            const seg1TforY = BezierUtils.tForY(segment1Points(), y);
+            const seg2TforY = BezierUtils.tForY(segment2Points(), y);
+
+            points = BezierUtils.splitSecond(segment1Points(), Math.max(seg1TforX, seg1TforY));
+            if (points.length === 0)
+                points = segment1Points();
+
+            const segment2 = BezierUtils.splitFirst(segment2Points(), Math.max(seg2TforX, seg2TforY));
+            if (segment2.length > 0)
+                points = points.concat(segment2.slice(1)); // The first point is a duplicate.
+            else
+                points = points.concat(segment2Points().slice(1)); // The first point is a duplicate.
+        } else if (midpoint.x > x) {
+            // Split the first segment.
+            const firstSegment = segment1Points();
+            const tForX = BezierUtils.tForX(firstSegment, x);
+            const tForY = BezierUtils.tForY(firstSegment, y);
+
+            if (x === firstSegment[0].x)
+                points = BezierUtils.splitFirst(firstSegment, tForY);
+             else if (tForX > 0 && tForY > tForX) {
+                const subsegment = BezierUtils.splitSecond(firstSegment, tForX);
+                const t = BezierUtils.tForY(subsegment, y);
+                points = BezierUtils.splitFirst(subsegment, t);
+            }
+        } else if (midpoint.y > y) {
+            // Split the second segment.
+            const secondSegment = segment2Points();
+            const tForX = BezierUtils.tForX(secondSegment, x);
+            const tForY = BezierUtils.tForY(secondSegment, y);
+            
+            if (y === secondSegment[3].y)
+                points = BezierUtils.splitSecond(secondSegment, tForX);
+            else if (tForX > 0 && tForY > tForX) {
+                const subsegment = BezierUtils.splitSecond(secondSegment, tForX);
+                const t = BezierUtils.tForY(subsegment, y);
+                points = BezierUtils.splitFirst(subsegment, t);
+            }
+        }
+
+        return new CornerCurve(points);
+    }
+}
+
+// Adapted from https://github.com/Pomax/bezierjs 
+
+const p1Index = 0;
+const c1Index = 1;
+const c2Index = 2;
+const p2Index = 3;
+
+class BezierUtils {
+
+    static approximately(a, b, precision)
+    {
+        const epsilon = 0.000001;
+        return Math.abs(a - b) <= (precision || epsilon);
+    }
+
+    // cube root function yielding real roots
+    static crt(v)
+    {
+        return v < 0 ? -Math.pow(-v, 1 / 3) : Math.pow(v, 1 / 3);
+    }
+
+
+    static align(points, line)
+    {
+        const tx = line.p1.x
+        const ty = line.p1.y;
+        const a = -Math.atan2(line.p2.y - ty, line.p2.x - tx);
+        const d = function(v) {
+            return {
+                x: (v.x - tx) * Math.cos(a) - (v.y - ty) * Math.sin(a),
+                y: (v.x - tx) * Math.sin(a) + (v.y - ty) * Math.cos(a),
+            };
+        };
+      return points.map(d);
+    }
+
+    static roots(points, line)
+    {
+        line = line || { p1: { x: 0, y: 0 }, p2: { x: 1, y: 0 } };
+
+        const order = points.length - 1;
+        const aligned = BezierUtils.align(points, line);
+        const reduce = function(t) {
+            return 0 <= t && t <= 1;
+        };
+
+        if (order === 2) {
+            const a = aligned[0].y;
+            const b = aligned[1].y;
+            const c = aligned[2].y;
+            const d = a - 2 * b + c;
+            if (d !== 0) {
+                  const m1 = -Math.sqrt(b * b - a * c);
+                  const m2 = -a + b;
+                  const v1 = -(m1 + m2) / d;
+                  const v2 = -(-m1 + m2) / d;
+              return [v1, v2].filter(reduce);
+          }
+          
+          if (b !== c && d === 0)
+              return [(2 * b - c) / (2 * b - 2 * c)].filter(reduce);
+
+          return [];
+        }
+
+        // see http://www.trans4mind.com/personal_development/mathematics/polynomials/cubicAlgebra.htm
+        const pa = aligned[0].y;
+        const pb = aligned[1].y;
+        const pc = aligned[2].y;
+        const pd = aligned[3].y;
+
+        const d = -pa + 3 * pb - 3 * pc + pd;
+        let a = 3 * pa - 6 * pb + 3 * pc;
+        let b = -3 * pa + 3 * pb;
+        let c = pa;
+
+        if (BezierUtils.approximately(d, 0)) {
+              // this is not a cubic curve.
+              if (BezierUtils.approximately(a, 0)) {
+                  // in fact, this is not a quadratic curve either.
+                  if (BezierUtils.approximately(b, 0)) {
+                      // in fact in fact, there are no solutions.
+                      return [];
+                  }
+                  // linear solution:
+                  return [-c / b].filter(reduce);
+              }
+              // quadratic solution:
+              const q = Math.sqrt(b * b - 4 * a * c);
+              const a2 = 2 * a;
+              return [(q - b) / a2, (-b - q) / a2].filter(reduce);
+        }
+
+        // at this point, we know we need a cubic solution:
+        a /= d;
+        b /= d;
+        c /= d;
+
+        const p = (3 * b - a * a) / 3;
+        const p3 = p / 3;
+        const q = (2 * a * a * a - 9 * a * b + 27 * c) / 27;
+        const q2 = q / 2;
+        const discriminant = q2 * q2 + p3 * p3 * p3;
+        
+        const tau = 2 * Math.PI;
+
+        if (discriminant < 0) {
+            const mp3 = -p / 3;
+            const mp33 = mp3 * mp3 * mp3;
+            const r = Math.sqrt(mp33);
+            const t = -q / (2 * r);
+            const cosphi = t < -1 ? -1 : t > 1 ? 1 : t;
+            const phi = Math.acos(cosphi);
+            const crtr = BezierUtils.crt(r);
+
+            const t1 = 2 * crtr;
+            const x1 = t1 * Math.cos(phi / 3) - a / 3;
+            const x2 = t1 * Math.cos((phi + tau) / 3) - a / 3;
+            const x3 = t1 * Math.cos((phi + 2 * tau) / 3) - a / 3;
+            return [x1, x2, x3].filter(reduce);
+        }
+        
+        if (discriminant === 0) {
+            const u1 = q2 < 0 ? BezierUtils.crt(-q2) : -BezierUtils.crt(q2);
+            const x1 = 2 * u1 - a / 3;
+            const x2 = -u1 - a / 3;
+            return [x1, x2].filter(reduce);
+        }
+        
+        const sd = Math.sqrt(discriminant);
+        const u1 = BezierUtils.crt(-q2 + sd);
+        const v1 = BezierUtils.crt(q2 + sd);
+        
+        const root = u1 - v1 - a / 3;
+        return [root].filter(reduce);
+    }
+
+    static tForX(points, x)
+    {
+        const line = {
+            p1: new Point(x, 0),
+            p2: new Point(x, 1)
+        };
+        const roots = BezierUtils.roots(points, line);
+        if (roots.length === 0)
+            return 0;
+        return roots[0];
+    }
+
+    static tForY(points, y)
+    {
+        const line = {
+            p1: new Point(0, y),
+            p2: new Point(1, y)
+        };
+        const roots = BezierUtils.roots(points, line);
+        if (roots.length === 0)
+            return 0;
+        return roots[0];
+    }
+
+    static splitFirst(points, t)
+    {
+        if (t === 0)
+            return [];
+
+        // Split using matrix math.
+        // https://pomax.github.io/bezierinfo/#splitting
+        const z = t;
+        
+        const first = function(z, p1, p2, p3, p4) {
+            const zMinusOne = z - 1;
+            return z * p2 - zMinusOne * p1;
+        };
+
+        const second = function(z, p1, p2, p3, p4) {
+            const zMinusOne = z - 1;
+            return z * z * p3 - 2 * z * zMinusOne * p2 + zMinusOne * zMinusOne * p1;
+        };
+
+        const third = function(z, p1, p2, p3, p4) {
+            const zMinusOne = z - 1;
+            return z * z * z * p4 - 3 * z * z * zMinusOne * p3 + 3 * z * zMinusOne * zMinusOne * p2 - zMinusOne * zMinusOne * zMinusOne * p1;
+        };
+
+        const startPoint = points[p1Index];
+        const endPoint = new Point(third(z, points[p1Index].x, points[c1Index].x, points[c2Index].x, points[p2Index].x), third(z, points[p1Index].y, points[c1Index].y, points[c2Index].y, points[p2Index].y));
+        const c1 = new Point(first(z, points[p1Index].x, points[c1Index].x, points[c2Index].x, points[p2Index].x), first(z, points[p1Index].y, points[c1Index].y, points[c2Index].y, points[p2Index].y));
+        const c2 = new Point(second(z, points[p1Index].x, points[c1Index].x, points[c2Index].x, points[p2Index].x), second(z, points[p1Index].y, points[c1Index].y, points[c2Index].y, points[p2Index].y));
+        return [startPoint, c1, c2, endPoint];
+    }
+
+    static splitSecond(points, t)
+    {
+        if (t === 0)
+            return [];
+
+        // Split using matrix math.
+        // https://pomax.github.io/bezierinfo/#splitting
+        const z = t;
+        
+        const first = function(z, p1, p2, p3, p4) {
+            const zMinusOne = z - 1;
+            return z * z * z * p4 - 3 * z * z * zMinusOne * p3 + 3 * z * zMinusOne * zMinusOne * p2 - zMinusOne * zMinusOne * zMinusOne * p1;
+        };
+
+        const second = function(z, p1, p2, p3, p4) {
+            const zMinusOne = z - 1;
+            return z * z * p4 - 2 * z * zMinusOne * p3 + zMinusOne * zMinusOne * p2;
+        };
+
+        const third = function(z, p1, p2, p3, p4) {
+            const zMinusOne = z - 1;
+            return z * p4 - zMinusOne * p3;
+        };
+
+        const startPoint = new Point(first(z, points[p1Index].x, points[c1Index].x, points[c2Index].x, points[p2Index].x), first(z, points[p1Index].y, points[c1Index].y, points[c2Index].y, points[p2Index].y));
+        const endPoint = points[p2Index];
+        const c1 = new Point(second(z, points[p1Index].x, points[c1Index].x, points[c2Index].x, points[p2Index].x), second(z, points[p1Index].y, points[c1Index].y, points[c2Index].y, points[p2Index].y));
+        const c2 = new Point(third(z, points[p1Index].x, points[c1Index].x, points[c2Index].x, points[p2Index].x), third(z, points[p1Index].y, points[c1Index].y, points[c2Index].y, points[p2Index].y));
+        return [startPoint, c1, c2, endPoint];
+    }
+    
 }

--- a/corner-visualizer/shape-renderer.html
+++ b/corner-visualizer/shape-renderer.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Corner visualizer</title>
+    <title>Shape Explorer</title>
     <style>
         :root {
             font-family: system-ui, san-serif;
@@ -14,8 +14,8 @@
         main {
             height: 100%;
             display: grid;
-            grid-template-rows: auto 1fr;
-            grid-template-columns: 1fr 0.6fr;
+            grid-template-rows: 1fr;
+            grid-template-columns: 1fr 1fr;
             gap: 10px;
         }
         
@@ -24,7 +24,7 @@
         }
         
         .preview {
-            grid-row: 1 / 3;
+            grid-row: 1;
             grid-column: 1;
             position: relative;
         }
@@ -35,9 +35,9 @@
             max-width: 700px;
         }
 
-        .explanation {
+        .details {
             grid-row: 2;
-            grid-column: 2;
+            grid-column: 1;
         }
         
         canvas {
@@ -72,9 +72,9 @@
         }
         
         .control-group {
-            grid-column: 1 / 3;
             display: grid;
-            grid-template-columns: 200px 1fr;
+            grid-template-columns: subgrid;
+            grid-column: 1 / 3;
             border: 1px solid #ddd;
             padding: 20px;
         }
@@ -87,9 +87,6 @@
             -webkit-user-select: none;
             user-select: none;
             margin-left: 0.5em;
-        }
-        
-        input[type='checkbox'] {
         }
 
         .slider {
@@ -107,11 +104,13 @@
     </style>
     <script src="../scripts/utils.js"></script>
     <script src="../scripts/geometry-utils.js"></script>
+    <script src="../scripts/observable.js"></script>
 
+    <script src="../scripts/shape.js"></script>
     <script src="../custom-elements/value-slider.js"></script>
     <script src="../custom-elements/popup.js"></script>
 
-    <script src="bezier-intersection.js" type="module"></script>
+    <script src="shape-renderer.js" type="module"></script>
 </head>
 <body>
     <main>
@@ -124,42 +123,34 @@
                 <div class="control-group">
 
                     <div class="labeled-control">
-                        <label class="radius-label">X offset</label><value-slider class="slider" id="border-left-width-slider" min="0" max="1" step="0.005" value=0.1></value-slider>
+                        <label class="radius-label">Left border width</label><value-slider class="slider" id="border-left-width-slider" min="0" max="1" step="0.005" value=0.15></value-slider>
                     </div>
                     <div class="labeled-control">
-                        <label class="radius-label">Y offset</label><value-slider class="slider" id="border-top-width-slider" min="0" max="1" step="0.005" value=0.1></value-slider>
-                    </div>
-
-                    <div class="labeled-control">
-                        <label class="s-label">S</label><value-slider class="slider" id="s-slider" min="-15" max="15" step="0.01" value="1"></value-slider>
+                        <label class="radius-label">Top border width</label><value-slider class="slider" id="border-top-width-slider" min="0" max="1" step="0.005" value=0.15></value-slider>
                     </div>
 
                     <div class="labeled-control">
-                        <div class="checkbox">
-                            <input id="show-control-points" type="checkbox" checked><label for="show-control-points">Show control points</label>
-                        </div>
-                        <div class="checkbox">
-                            <input id="show-classic-se" type="checkbox"><label for="show-classic-se">Show <span style="color: red">classic superellipse</span></label>
-                        </div>
-                        <div class="checkbox">
-                            <input id="show-math-se" type="checkbox"><label for="show-math-se">Show <span style="color: purple">t-interpolated superellipse</span></label>
-                        </div>
-                        <div class="checkbox">
-                            <input id="show-bezier-se" type="checkbox" checked><label for="show-bezier-se">Show <span style="color: gray">bezier superellipse<span></label>
-                        </div>
+                        <label class="radius-label">Border radius X %</label><value-slider class="slider" id="border-radius-x-slider" min="0" max="1" step="0.005" value=0.2></value-slider>
+                    </div>
+                    <div class="labeled-control">
+                        <label class="radius-label">Border radius Y %</label><value-slider class="slider" id="border-radius-y-slider" min="0" max="1" step="0.005" value=0.2></value-slider>
+                    </div>
+
+                    <label>Corner style:</label>
+                    <div class="labeled-control">
+                        <custom-popup id="corner-style-select"></custom-popup>
+                    </div>
+
+                    <div class="labeled-control">
+                        <label class="s-label">Superellipse S</label><value-slider class="slider" id="s-slider" min="-15" max="15" step="0.05" value="-1"></value-slider>
+                    </div>
+
+                    <div class="labeled-control">
+                        <input id="show-control-points" type="checkbox" checked><label for="show-control-points">Show control points</label>
                     </div>
                 </div>
 
             </div>
-        </section>
-        <section class="explanation">
-            <p>This view compares rendering of the classic superellipse (<code>x^k + y^k = 1</code>) in green, with a rendering based on <code>t</code> interpolation (purple) and a derived bezier curve (gray, with control points.)</p>
-            
-            <p>The slider controls the curvature param <code>s</code>, which is mapped to <code>k</code> via <code>k = Math.pow(2, s)</code>.
-
-            <p>For symmetry around <code>s=0</code>, the <code>t</code> interpolation and bezier curves use <code>abs(s)</code> mapped into the negative s region, hence the deviation from the green line.</p>
-
-            <p>The red point demonstrates the math to compute Y given X.</p>
         </section>
     </main>
 

--- a/corner-visualizer/shape-renderer.js
+++ b/corner-visualizer/shape-renderer.js
@@ -1,0 +1,148 @@
+import {
+    cornerStyleNone,
+    cornerStyleStraight,
+    cornerStyleRound,
+    cornerStyleNotch,
+    cornerStyleBevel,
+    cornerStyleScoop,
+    cornerStyleSuperellipse,
+    cornerStyleSuperellipseApproximation,
+    cornerStyleContinuousRounded,
+    ShapeParameters,
+    BorderRenderer,
+} from "./corner-renderer.js";
+
+const cornerStyles = [
+    {
+        name: 'Straight',
+        value: 'straight',
+        data: cornerStyleStraight
+    },
+    {
+        name: 'Round',
+        value: 'rounde',
+        data: cornerStyleRound
+    },
+    {
+        name: 'Scoop',
+        value: 'scoop',
+        data: cornerStyleScoop
+    },
+    {
+        name: 'Notch',
+        value: 'notch',
+        data: cornerStyleNotch
+    },
+    {
+        name: 'Bevel',
+        value: 'bevel',
+        data: cornerStyleBevel
+    },
+    {
+        name: 'Superellipse',
+        value: 'superellipse',
+        data: cornerStyleSuperellipse
+    },
+    {
+        name: 'Continuous Rounded (Apple)',
+        value: 'continuous-rounded',
+        data: cornerStyleContinuousRounded
+    },
+];
+
+class WindowController {
+    constructor()
+    {
+        this.canvasElement = document.getElementById('preview-canvas');
+        
+        this.parameters = new ShapeParameters();
+        this.previewRenderer = new BorderRenderer(this.canvasElement, this.parameters);
+        
+        this.#registerCustomElements();
+        this.#connectControls();
+    }
+
+    #registerCustomElements()
+    {
+        window.customElements.define("custom-popup", PopupElement);   
+        window.customElements.define("value-slider", ValueSlider);   
+    }
+    
+    #connectControls()
+    {
+        this.sSlider = document.getElementById('s-slider');
+
+        const setupSlider = (sliderID, paramName) => {
+            const slider = document.getElementById(sliderID);
+            slider.oninput = (event) => {
+                this.parameters[paramName] = parseFloat(slider.value);
+                this.#parametersChanged();
+            }
+            this.parameters[paramName] = parseFloat(slider.value);
+        };
+
+        setupSlider('s-slider', 'superEllipseParam');
+        setupSlider('border-radius-x-slider', 'borderRadiusWidth');
+        setupSlider('border-radius-y-slider', 'borderRadiusHeight');
+
+        setupSlider('border-left-width-slider', 'borderLeftWidth');
+        setupSlider('border-top-width-slider', 'borderTopWidth');
+
+        const cornerStyleSelect = document.getElementById('corner-style-select');
+        cornerStyleSelect.setValues(cornerStyles);
+        cornerStyleSelect.addEventListener('change', () => {
+            for (const style of cornerStyles) {
+                if (style.value === cornerStyleSelect.currentValue) {
+                    this.#cornerStyleChanged(style.data);
+                    break;
+                }
+            }
+        });
+        cornerStyleSelect.selectedIndex = 5;
+
+        const showControlPointsCheckbox = document.getElementById('show-control-points');
+        showControlPointsCheckbox.addEventListener('change', (event) => {
+            this.parameters.showControlPoints = event.target.checked;
+            this.#parametersChanged();
+        });
+        this.parameters.showControlPoints = showControlPointsCheckbox.checked;
+
+        this.#parametersChanged();
+    }
+    
+    #cornerStyleChanged(newStyle)
+    {
+        this.parameters.cornerStyle = newStyle;
+        
+        switch (newStyle) {
+        case cornerStyleStraight:
+            this.parameters.superEllipseParam = 15;
+            break;
+        case cornerStyleRound:
+            this.parameters.superEllipseParam = 1;
+            break;
+        case cornerStyleScoop:
+            this.parameters.superEllipseParam = -1;
+            break;
+        case cornerStyleNotch:
+            this.parameters.superEllipseParam = -15;
+            break;
+        case cornerStyleBevel:
+            this.parameters.superEllipseParam = 0;
+            break;
+        }
+        
+        this.sSlider.value = this.parameters.superEllipseParam;
+        this.#parametersChanged();
+    }
+
+    #parametersChanged()
+    {
+        this.previewRenderer.parameters = this.parameters;
+    }
+}
+
+let windowController;
+window.addEventListener('load', () => {
+    windowController = new WindowController();
+}, false);

--- a/custom-elements/popup.js
+++ b/custom-elements/popup.js
@@ -14,7 +14,8 @@ class PopupElement extends HTMLElement {
         const style = document.createElement("style");
         style.innerHTML = `
             select {
-                font-size: 12px;
+                margin: 10px;
+                font-size: 16px;
             }
         `;
         this.shadowRoot.appendChild(style);

--- a/scripts/geometry-utils.js
+++ b/scripts/geometry-utils.js
@@ -35,7 +35,7 @@ class Point {
     
     toString()
     {
-        return `x: ${this.x}, y: ${this.y}`;
+        return `x: ${this.x.toFixed(3)}, y: ${this.y.toFixed(3)}`;
     }
 }
 
@@ -50,6 +50,32 @@ class Size {
     scaledBy(scale)
     {
         return new Size(this.width * scale.width, this.height * scale.height);
+    }
+
+    addedTo(size)
+    {
+        return new Size(this.width + size.width, this.height + size.height);
+    }
+    
+    flipped()
+    {
+        return new Size(this.height, this.width);
+    }
+
+    clone()
+    {
+        return new Size(this.width, this.height);
+    }
+    
+    normalized()
+    {
+        const hypot = Math.hypot(this.width, this.height);
+        return new Size(this.width / hypot, this.height / hypot);
+    }
+
+    toString()
+    {
+        return `x: ${this.width.toFixed(5)}, y: ${this.height.toFixed(5)}`;
     }
 }
 


### PR DESCRIPTION
bezier-intersection.html is a proving ground for comparing the bezier-based superellipse with the iterative version, and for validating the bezier splitting logic required for inner edges.

corner-geometry.html presents the math required to compute inner superellipse curves, showing the offset corner points and control points.

shape-renderer.html is a playground for the various CSS corner treatments, and computes the full inner and outer bezier curves.